### PR TITLE
Update README and help of printstruct to show correct argument names

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,7 @@ Run `printstruct` with no args prints help and shows default VARARGINs
 | nindent        | number of tab indents for each line of printed struct |
 | structname     | top level name (if empty, variable name will be used) |
 | printcontents  | flag to print field values/contents as well           |
-| maxarraylength | for fields with array data, max length of values to   |
-  print. Values of a 2-D (m,n) array are printed if the number of
-  elements (m x n) is smaller or equal to maxarraylength. This is ignored
-  if printvalues is 0.        |
+| maxarraylength | for fields with array data, max length of values to print. Values of a 2-D (m,n) array are printed if the number of elements (m x n) is smaller or equal to maxarraylength. This is ignored if printvalues is 0.        |
 
 - run `printstruct` w/no arguments to see default values
 

--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ Run `printstruct` with no args prints help and shows default VARARGINs
 
     pS = printstruct(S, 'maxarray', 100); 
 
-    printstruct(S, 'nlev', 2, 'printcont', 0, 'nindent', 3)
+    printstruct(S, 'nlevels', 2, 'printcontents', 0, 'nindent', 3)
 

--- a/printstruct.m
+++ b/printstruct.m
@@ -27,7 +27,7 @@ function pS = printstruct(S, varargin)
 % EXAMPLES
 % 
 %   pS = printstruct(S, 'maxarray', 100); 
-%   printstruct(S, 'nlev', 2, 'printcont', 0, 'nindent', 3)
+%   printstruct(S, 'nlevels', 2, 'printcontents', 0, 'nindent', 3)
 % 
 
 % ---------------------- Copyright (C) 2015 Bob Spunt ----------------------


### PR DESCRIPTION
Previous version would show arguments as 'nlev' and 'printcont' as available in both the README as well as the help for printstruct.
This PR makes both parts be the correct version as in the argument accepted by printstruct namely 'nlev' becomes 'nlevels' and 'printcont' becomes 'printcontents'.
